### PR TITLE
Add option to URL decode content body prior to passing to JSON unmarshalling

### DIFF
--- a/request.go
+++ b/request.go
@@ -37,9 +37,9 @@ func (self *Request) DecodeJsonPayload(v interface{}, decodeBody bool) error {
 	if err != nil {
 		return err
 	}
-    contentstr := ""
+    contentstr := CToGoString(content)
     if decodeBody == true {
-        contentstr, _ = url.QueryUnescape(CToGoString(content))
+        contentstr, _ = url.QueryUnescape(contentstr)
     }
 	err = json.Unmarshal([]byte(contentstr), v)
 	if err != nil {


### PR DESCRIPTION
This patch will allow developers consuming this library to optionally URL decode content body. I have a case where the content body is fully URL-encoded and needs to be decoded manually server-side.
