### PR TITLE
Add support for URL prefixes

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -111,7 +111,7 @@ func RouteObjectMethod(httpMethod string, pathExp string, objectInstance interfa
 // SetRoutes defines the Routes. The order the Routes matters,
 // if a request matches multiple Routes, the first one will be used.
 func (rh *ResourceHandler) SetRoutes(routes ...Route) error {
-	
+
 	// start the router
 	rh.internalRouter = &router{
 		routes: routes,


### PR DESCRIPTION
Usage example:

```
handler := rest.ResourceHandler{}
handler.SetRoutes(
    rest.Route{"GET"        ,"/countries"       ,GetAllCountries},
    rest.Route{"POST"       ,"/countries"       ,PostCountry},
    rest.Route{"GET"        ,"/countries/:code" ,GetCountry},
    rest.Route{"DELETE"     ,"/countries/:code" ,DeleteCountry},
)
handler.Handle("/api/")
http.ListenAndServe(":12345", nil)
```
