### PR TITLE
use gopkg.in to vendor subpackages so v1 can be used in gopkg.in

### DIFF
--- a/gzip_test.go
+++ b/gzip_test.go
@@ -1,7 +1,7 @@
 package rest
 
 import (
-	"github.com/ant0ine/go-json-rest/test"
+	"gopkg.in/ant0ine/go-json-rest.v1/test"
 	"testing"
 )
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,7 +1,7 @@
 package rest
 
 import (
-	"github.com/ant0ine/go-json-rest/test"
+	"gopkg.in/ant0ine/go-json-rest.v1/test"
 	"io/ioutil"
 	"log"
 	"testing"

--- a/router.go
+++ b/router.go
@@ -2,7 +2,7 @@ package rest
 
 import (
 	"errors"
-	"github.com/ant0ine/go-json-rest/trie"
+	"gopkg.in/ant0ine/go-json-rest.v1/trie"
 	"net/url"
 	"strings"
 )

--- a/status_test.go
+++ b/status_test.go
@@ -1,7 +1,7 @@
 package rest
 
 import (
-	"github.com/ant0ine/go-json-rest/test"
+	"gopkg.in/ant0ine/go-json-rest.v1/test"
 	"testing"
 )
 


### PR DESCRIPTION
**This PR is for manually merging into v1.0.1 tag, NOT master...**

So that this now works for v1.0.x:

```
import (
  "gopkg.in/ant0ine/go-json-rest.v1"
)
```
