### PR TITLE
Support for X-Powered-By being user configurable, including disabling

### DIFF
--- a/rest/handler.go
+++ b/rest/handler.go
@@ -59,6 +59,12 @@ type ResourceHandler struct {
 
 	// Custom logger, optional, defaults to log.New(os.Stderr, "", log.LstdFlags)
 	Logger *log.Logger
+
+	// Custom X-Powered-By value, defaults to "go-json-rest".
+	XPoweredBy string
+
+	// If true, the X-Powered-By header will NOT be set.
+	DisableXPoweredBy bool
 }
 
 // SetRoutes defines the Routes. The order the Routes matters,
@@ -72,6 +78,14 @@ func (rh *ResourceHandler) SetRoutes(routes ...*Route) error {
 	err := rh.internalRouter.start()
 	if err != nil {
 		return err
+	}
+
+	if rh.DisableXPoweredBy {
+		rh.XPoweredBy = ""
+	} else {
+		if len(rh.XPoweredBy) == 0 {
+			rh.XPoweredBy = xPoweredByDefault
+		}
 	}
 
 	rh.instantiateMiddlewares()
@@ -152,7 +166,7 @@ func (rh *ResourceHandler) adapter(handler HandlerFunc) http.HandlerFunc {
 			origWriter,
 			false,
 			isIndented,
-			xPoweredByDefault,
+			rh.XPoweredBy,
 		}
 
 		// call the wrapped handler

--- a/rest/response.go
+++ b/rest/response.go
@@ -59,7 +59,9 @@ type responseWriter struct {
 
 func (w *responseWriter) WriteHeader(code int) {
 	w.Header().Set("content-type", "application/json")
-	w.Header().Add("X-Powered-By", w.xPoweredBy)
+	if len(w.xPoweredBy) > 0 {
+		w.Header().Add("X-Powered-By", w.xPoweredBy)
+	}
 	w.ResponseWriter.WriteHeader(code)
 	w.wroteHeader = true
 }


### PR DESCRIPTION
This PR makes it possible to control the X-Powered-By header sent by go-json-rest applications. This includes disabling sending the header for those applications that may wish to (eg to save a tiny amount of bandwidth, or for [security reasons](http://serverfault.com/questions/395332/whats-the-use-of-x-powered-by-server-and-other-similar-http-headers)).

I have added a test that ensures the existing, default behaviour remains sending the header. There are additional tests which demonstrate changing the header or disabling it entirely.
