### PR TITLE
Let resource handlers write arbitrary data, not solely JSON

### DIFF
--- a/rest/response.go
+++ b/rest/response.go
@@ -61,7 +61,10 @@ type responseWriter struct {
 }
 
 func (w *responseWriter) WriteHeader(code int) {
-	w.Header().Set("content-type", "application/json")
+	// do not overwrite Content-Type if previously set.
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
 	if len(w.xPoweredBy) > 0 {
 		w.Header().Add("X-Powered-By", w.xPoweredBy)
 	}


### PR DESCRIPTION
Expose the `Http.ResponseWrite.Write([]byte)` so that resource handlers have the possibility to write raw data as a response (plain/text, html, ...).

Avoid the response's `Content-Type` to be `application/json` only, in order to deal with the functionality above (`text/plain`, `text/html`, ...).
