### PR TITLE
Fix godoc in rest/test/doc.go

### DIFF
--- a/rest/test/doc.go
+++ b/rest/test/doc.go
@@ -15,9 +15,9 @@
 //	func TestSimpleRequest(t *testing.T) {
 //		handler := ResourceHandler{}
 //		handler.SetRoutes(
-// 		&Route{"GET", "/r",
-// 			func(w ResponseWriter, r *Request) {
-// 				w.WriteJson(map[string]string{"Id": "123"})
+//			&Route{"GET", "/r",
+//				func(w ResponseWriter, r *Request) {
+//					w.WriteJson(map[string]string{"Id": "123"})
 //				},
 //			},
 //		)


### PR DESCRIPTION
Hello I fix `doc.go` in rest/test/doc.go to show example when run godoc and test api in example use `MakeSessionRequest` I change it to `MakeSimpleRequest`  and HTTP Method

please review it
Thank you
