### PR TITLE
Don't copy regexp.Regexp during range

### DIFF
--- a/rest/router_benchmark_test.go
+++ b/rest/router_benchmark_test.go
@@ -109,7 +109,7 @@ func BenchmarkRegExpLoop(b *testing.B) {
 	if err != nil {
 		panic(err)
 	}
-	routeRegexps := []regexp.Regexp{}
+	routeRegexps := []*regexp.Regexp{}
 	for _, route := range routes {
 
 		// generate the regexp string
@@ -123,7 +123,7 @@ func BenchmarkRegExpLoop(b *testing.B) {
 			panic(err)
 		}
 
-		routeRegexps = append(routeRegexps, *reg)
+		routeRegexps = append(routeRegexps, reg)
 	}
 
 	b.StartTimer()


### PR DESCRIPTION
Regexps have a sync.Mutex field, which is not
safe to copy. Future versions of go vet will
likely flag this (golang.org/issue/8356).

This also allows the Regexp to re-use its machine
during benchmarking, to nice effect:

benchmark                  old ns/op     new ns/op     delta
BenchmarkRegExpLoop        721637        192566        -73.32%
