### PR TITLE
Fixed "using unaddressable value"

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ func (api *Api) InitDB() {
 }
 
 func (api *Api) InitSchema() {
-	api.DB.AutoMigrate(Reminder{})
+	api.DB.AutoMigrate(&Reminder{})
 }
 
 func (api *Api) GetAllReminders(w rest.ResponseWriter, r *rest.Request) {


### PR DESCRIPTION
I'm new to Go, and was trying to run the example, but got "using unaddressable value" on this line. Seems like the ampersand was missing.
