### PR TITLE
Preparation Refactoring before v3 work.

### DIFF
--- a/rest/adapter.go
+++ b/rest/adapter.go
@@ -1,0 +1,47 @@
+package rest
+
+import (
+	"net/http"
+)
+
+const xPoweredByDefault = "go-json-rest"
+
+// Handle the transition between net/http and go-json-rest objects.
+// It intanciates the rest.Request and rest.ResponseWriter, ...
+type jsonAdapter struct {
+	DisableJsonIndent bool
+	XPoweredBy        string
+	DisableXPoweredBy bool
+}
+
+func (ja *jsonAdapter) AdapterFunc(handler HandlerFunc) http.HandlerFunc {
+
+	poweredBy := ""
+	if !ja.DisableXPoweredBy {
+		if ja.XPoweredBy == "" {
+			poweredBy = xPoweredByDefault
+		} else {
+			poweredBy = ja.XPoweredBy
+		}
+	}
+
+	return func(origWriter http.ResponseWriter, origRequest *http.Request) {
+
+		// instantiate the rest objects
+		request := &Request{
+			origRequest,
+			nil,
+			map[string]interface{}{},
+		}
+
+		writer := &responseWriter{
+			origWriter,
+			false,
+			!ja.DisableJsonIndent,
+			poweredBy,
+		}
+
+		// call the wrapped handler
+		handler(writer, request)
+	}
+}

--- a/rest/content_type_checker.go
+++ b/rest/content_type_checker.go
@@ -1,0 +1,37 @@
+package rest
+
+import (
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// contentTypeCheckerMiddleware verify the Request content type and returns a
+// StatusUnsupportedMediaType (415) HTTP error response if it's incorrect.
+type contentTypeCheckerMiddleware struct{}
+
+// MiddlewareFunc returns a HandlerFunc that implements the middleware.
+func (mw *contentTypeCheckerMiddleware) MiddlewareFunc(handler HandlerFunc) HandlerFunc {
+
+	return func(w ResponseWriter, r *Request) {
+
+		mediatype, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		charset, ok := params["charset"]
+		if !ok {
+			charset = "UTF-8"
+		}
+
+		if r.ContentLength > 0 && // per net/http doc, means that the length is known and non-null
+			!(mediatype == "application/json" && strings.ToUpper(charset) == "UTF-8") {
+
+			Error(w,
+				"Bad Content-Type or charset, expected 'application/json'",
+				http.StatusUnsupportedMediaType,
+			)
+			return
+		}
+
+		// call the wrapped handler
+		handler(w, r)
+	}
+}

--- a/rest/response.go
+++ b/rest/response.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 )
 
-const xPoweredByDefault = "go-json-rest"
-
 // A ResponseWriter interface dedicated to JSON HTTP response.
 // Note that the object instantiated by the ResourceHandler that implements this interface,
 // also happens to implement http.ResponseWriter, http.Flusher and http.CloseNotifier.

--- a/rest/router_benchmark_test.go
+++ b/rest/router_benchmark_test.go
@@ -58,7 +58,7 @@ func BenchmarkNoCompression(b *testing.B) {
 	b.StopTimer()
 
 	r := router{
-		routes:                 routes(),
+		Routes:                 routes(),
 		disableTrieCompression: true,
 	}
 	r.start()
@@ -78,7 +78,7 @@ func BenchmarkCompression(b *testing.B) {
 	b.StopTimer()
 
 	r := router{
-		routes: routes(),
+		Routes: routes(),
 	}
 	r.start()
 	urlObjs := requestUrls()

--- a/rest/router_test.go
+++ b/rest/router_test.go
@@ -9,7 +9,7 @@ import (
 func TestFindRouteAPI(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/",
@@ -74,7 +74,7 @@ func TestFindRouteAPI(t *testing.T) {
 func TestNoRoute(t *testing.T) {
 
 	r := router{
-		routes: []*Route{},
+		Routes: []*Route{},
 	}
 
 	err := r.start()
@@ -102,7 +102,7 @@ func TestNoRoute(t *testing.T) {
 func TestEmptyPathExp(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "",
@@ -119,7 +119,7 @@ func TestEmptyPathExp(t *testing.T) {
 func TestInvalidPathExp(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "invalid",
@@ -136,7 +136,7 @@ func TestInvalidPathExp(t *testing.T) {
 func TestUrlEncodedFind(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/with space", // not urlencoded
@@ -165,7 +165,7 @@ func TestUrlEncodedFind(t *testing.T) {
 func TestWithQueryString(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/r/:id",
@@ -197,7 +197,7 @@ func TestWithQueryString(t *testing.T) {
 func TestNonUrlEncodedFind(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/with%20space", // urlencoded
@@ -226,7 +226,7 @@ func TestNonUrlEncodedFind(t *testing.T) {
 func TestDuplicatedRoute(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/",
@@ -247,7 +247,7 @@ func TestDuplicatedRoute(t *testing.T) {
 func TestSplatUrlEncoded(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/r/*rest",
@@ -279,7 +279,7 @@ func TestSplatUrlEncoded(t *testing.T) {
 func TestRouteOrder(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/r/:id",
@@ -318,7 +318,7 @@ func TestRouteOrder(t *testing.T) {
 func TestRelaxedPlaceholder(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/r/:id",
@@ -357,7 +357,7 @@ func TestRelaxedPlaceholder(t *testing.T) {
 func TestSimpleExample(t *testing.T) {
 
 	r := router{
-		routes: []*Route{
+		Routes: []*Route{
 			&Route{
 				HttpMethod: "GET",
 				PathExp:    "/resources/:id",


### PR DESCRIPTION
This does not introduce any API change.
It refactors the internal of ResourceHandler. The the logic of this handler
is now much simpler. All it does is to instantiate the adapter, the middlewares
and the router. It does this in the right order, and according to the settings.

Essentially, the adapter, the middlewares and the router become the low level API
of go-json-api (private API for now) and ResourceHandler is the a convenient
shortcut to intantiate all this. V3 could come with the new API on top of this low
level API.
