### PR TITLE
#112: add ACL support for basic auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ func main() {
 		PreRoutingMiddlewares: []rest.Middleware{
 			&rest.AuthBasicMiddleware{
 				Realm: "test zone",
-				Authenticator: func(userId string, password string) bool {
+				Authenticator: func(userId string, password string, request *Request) bool {
 					if userId == "admin" && password == "admin" {
 						return true
 					}

--- a/rest/auth_basic.go
+++ b/rest/auth_basic.go
@@ -18,7 +18,7 @@ type AuthBasicMiddleware struct {
 
 	// Callback function that should perform the authentication of the user based on
 	// userId and password. Must return true on success, false on failure. (Required)
-	Authenticator func(userId string, password string) bool
+	Authenticator func(userId string, password string, request *Request) bool
 }
 
 // MiddlewareFunc tries to authenticate the user. It sends a 401 on failure,
@@ -48,7 +48,7 @@ func (mw *AuthBasicMiddleware) MiddlewareFunc(handler HandlerFunc) HandlerFunc {
 			return
 		}
 
-		if !mw.Authenticator(providedUserId, providedPassword) {
+		if !mw.Authenticator(providedUserId, providedPassword, request) {
 			mw.unauthorized(writer)
 			return
 		}

--- a/rest/auth_basic_test.go
+++ b/rest/auth_basic_test.go
@@ -12,7 +12,7 @@ func TestAuthBasic(t *testing.T) {
 		PreRoutingMiddlewares: []Middleware{
 			&AuthBasicMiddleware{
 				Realm: "test zone",
-				Authenticator: func(userId string, password string) bool {
+				Authenticator: func(userId string, password string, request *Request) bool {
 					if userId == "admin" && password == "admin" {
 						return true
 					}


### PR DESCRIPTION
pass `request *Request` parameter to Authenticator signature, to incorprate with issue #112 