### PR TITLE
create a new middleware jsonIndentMiddleware

### DIFF
--- a/rest/access_log_apache_test.go
+++ b/rest/access_log_apache_test.go
@@ -41,7 +41,6 @@ func TestAccessLogApacheMiddleware(t *testing.T) {
 	w := &responseWriter{
 		httptest.NewRecorder(),
 		false,
-		false,
 		"",
 	}
 

--- a/rest/access_log_json_test.go
+++ b/rest/access_log_json_test.go
@@ -39,7 +39,6 @@ func TestAccessLogJsonMiddleware(t *testing.T) {
 	w := &responseWriter{
 		httptest.NewRecorder(),
 		false,
-		false,
 		"",
 	}
 

--- a/rest/adapter.go
+++ b/rest/adapter.go
@@ -9,7 +9,6 @@ const xPoweredByDefault = "go-json-rest"
 // Handle the transition between net/http and go-json-rest objects.
 // It intanciates the rest.Request and rest.ResponseWriter, ...
 type jsonAdapter struct {
-	DisableJsonIndent bool
 	XPoweredBy        string
 	DisableXPoweredBy bool
 }
@@ -37,7 +36,6 @@ func (ja *jsonAdapter) AdapterFunc(handler HandlerFunc) http.HandlerFunc {
 		writer := &responseWriter{
 			origWriter,
 			false,
-			!ja.DisableJsonIndent,
 			poweredBy,
 		}
 

--- a/rest/handler.go
+++ b/rest/handler.go
@@ -127,6 +127,10 @@ func (rh *ResourceHandler) SetRoutes(routes ...*Route) error {
 		middlewares = append(middlewares, &gzipMiddleware{})
 	}
 
+	if !rh.DisableJsonIndent {
+		middlewares = append(middlewares, &jsonIndentMiddleware{})
+	}
+
 	// catch user errors
 	middlewares = append(middlewares,
 		&recoverMiddleware{
@@ -158,7 +162,6 @@ func (rh *ResourceHandler) SetRoutes(routes ...*Route) error {
 
 	// intantiate the adapter
 	adapter := &jsonAdapter{
-		DisableJsonIndent: rh.DisableJsonIndent,
 		XPoweredBy:        rh.XPoweredBy,
 		DisableXPoweredBy: rh.DisableXPoweredBy,
 	}

--- a/rest/json_indent.go
+++ b/rest/json_indent.go
@@ -1,0 +1,113 @@
+package rest
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"net/http"
+)
+
+// jsonIndentMiddleware provides JSON encoding with indentation.
+// It could be convenient to use it during development.
+// It works by "subclassing" the responseWriter provided by the wrapping middleware,
+// replacing the writer.EncodeJson and writer.WriteJson implementations,
+// and making the parent implementations ignored.
+type jsonIndentMiddleware struct {
+
+	// prefix string, as in json.MarshalIndent
+	Prefix string
+
+	// indentation string, as in json.MarshalIndent
+	Indent string
+}
+
+// MiddlewareFunc makes jsonIndentMiddleware implement the Middleware interface.
+func (mw *jsonIndentMiddleware) MiddlewareFunc(handler HandlerFunc) HandlerFunc {
+
+	if mw.Indent == "" {
+		mw.Indent = "  "
+	}
+
+	return func(w ResponseWriter, r *Request) {
+
+		writer := &jsonIndentResponseWriter{w, false, mw.Prefix, mw.Indent}
+		// call the wrapped handler
+		handler(writer, r)
+	}
+}
+
+// Private responseWriter intantiated by the middleware.
+// It implements the following interfaces:
+// ResponseWriter
+// http.ResponseWriter
+// http.Flusher
+// http.CloseNotifier
+// http.Hijacker
+type jsonIndentResponseWriter struct {
+	ResponseWriter
+	wroteHeader bool
+	prefix      string
+	indent      string
+}
+
+// Replace the parent EncodeJson to provide indentation.
+func (w *jsonIndentResponseWriter) EncodeJson(v interface{}) ([]byte, error) {
+	b, err := json.MarshalIndent(v, w.prefix, w.indent)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Make sure the local EncodeJson and local Write are called.
+// Does not call the parent WriteJson.
+func (w *jsonIndentResponseWriter) WriteJson(v interface{}) error {
+	b, err := w.EncodeJson(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Call the parent WriteHeader.
+func (w *jsonIndentResponseWriter) WriteHeader(code int) {
+	w.ResponseWriter.WriteHeader(code)
+	w.wroteHeader = true
+}
+
+// Make sure the local WriteHeader is called, and call the parent Flush.
+// Provided in order to implement the http.Flusher interface.
+func (w *jsonIndentResponseWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	flusher := w.ResponseWriter.(http.Flusher)
+	flusher.Flush()
+}
+
+// Call the parent CloseNotify.
+// Provided in order to implement the http.CloseNotifier interface.
+func (w *jsonIndentResponseWriter) CloseNotify() <-chan bool {
+	notifier := w.ResponseWriter.(http.CloseNotifier)
+	return notifier.CloseNotify()
+}
+
+// Provided in order to implement the http.Hijacker interface.
+func (w *jsonIndentResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker := w.ResponseWriter.(http.Hijacker)
+	return hijacker.Hijack()
+}
+
+// Make sure the local WriteHeader is called, and call the parent Write.
+// Provided in order to implement the http.ResponseWriter interface.
+func (w *jsonIndentResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	writer := w.ResponseWriter.(http.ResponseWriter)
+	return writer.Write(b)
+}

--- a/rest/json_indent_test.go
+++ b/rest/json_indent_test.go
@@ -1,0 +1,43 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestJsonIndentMiddleware(t *testing.T) {
+
+	jsonIndent := &jsonIndentMiddleware{}
+
+	app := func(w ResponseWriter, r *Request) {
+		w.WriteJson(map[string]string{"Id": "123"})
+	}
+
+	handlerFunc := WrapMiddlewares([]Middleware{jsonIndent}, app)
+
+	// fake request
+	origRequest, _ := http.NewRequest("GET", "http://localhost/", nil)
+	origRequest.RemoteAddr = "127.0.0.1:1234"
+	r := &Request{
+		origRequest,
+		nil,
+		map[string]interface{}{},
+	}
+
+	// fake writer
+
+	recorder := httptest.NewRecorder()
+	w := &responseWriter{
+		recorder,
+		false,
+		"",
+	}
+
+	handlerFunc(w, r)
+
+	expected := "{\n  \"Id\": \"123\"\n}"
+	if recorder.Body.String() != expected {
+		t.Errorf("expected %s, got : %s", expected, recorder.Body)
+	}
+}

--- a/rest/recorder_test.go
+++ b/rest/recorder_test.go
@@ -27,7 +27,6 @@ func TestRecorderMiddleware(t *testing.T) {
 	w := &responseWriter{
 		httptest.NewRecorder(),
 		false,
-		false,
 		"",
 	}
 
@@ -75,7 +74,6 @@ func TestRecorderAndGzipMiddleware(t *testing.T) {
 	// fake writer
 	w := &responseWriter{
 		httptest.NewRecorder(),
-		false,
 		false,
 		"",
 	}

--- a/rest/response.go
+++ b/rest/response.go
@@ -57,7 +57,6 @@ func NotFound(w ResponseWriter, r *Request) {
 type responseWriter struct {
 	http.ResponseWriter
 	wroteHeader bool
-	isIndented  bool
 	xPoweredBy  string
 }
 
@@ -73,13 +72,7 @@ func (w *responseWriter) WriteHeader(code int) {
 }
 
 func (w *responseWriter) EncodeJson(v interface{}) ([]byte, error) {
-	var b []byte
-	var err error
-	if w.isIndented {
-		b, err = json.MarshalIndent(v, "", "  ")
-	} else {
-		b, err = json.Marshal(v)
-	}
+	b, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/response_test.go
+++ b/rest/response_test.go
@@ -11,7 +11,6 @@ func TestResponseNotIndent(t *testing.T) {
 	writer := responseWriter{
 		nil,
 		false,
-		false,
 		xPoweredByDefault,
 	}
 


### PR DESCRIPTION
This is a way to replace the jsonAdapter option by a middleware option.
It could be a lot of code and complexity for a small win.
But it also provides more options (prefix and indent strings)