### PR TITLE
added jwt authentication middleware

### DIFF
--- a/rest/jwt_auth.go
+++ b/rest/jwt_auth.go
@@ -1,0 +1,137 @@
+package rest
+
+import (
+	"github.com/dgrijalva/jwt-go"
+
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// JWTMiddleware provides a Json-Webtoken authentication implementation. On failure, a 401 HTTP response
+// is returned. On success, the wrapped middleware is called, and the userId is made available as
+// request.Env["REMOTE_USER"].(string)
+type JWTMiddleware struct {
+	// Realm name to display to the user. Required.
+	Realm string
+
+	// signing algorithm - possible values are HS256, HS384, HS512
+	// Optional, default is HS256
+	SigningAlgorithm string
+
+	// Secret key used for signing. Required
+	Key []byte
+
+	// Duration that a jwt token is valid. Optional, default is one hour
+	Timeout time.Duration
+
+	// Callback function that should perform the authentication of the user based on userId and
+	// password. Must return true on success, false on failure. Required.
+	Authenticator func(userId string, password string) bool
+
+	// Callback function that should perform the authorization of the authenticated user. Called
+	// only after an authentication success. Must return true on success, false on failure.
+	// Optional, default to success.
+	Authorizator func(userId string, request *Request) bool
+}
+
+// MiddlewareFunc makes JWTMiddleware implement the Middleware interface.
+func (mw *JWTMiddleware) MiddlewareFunc(handler HandlerFunc) HandlerFunc {
+
+	if mw.Realm == "" {
+		log.Fatal("Realm is required")
+	}
+	if mw.SigningAlgorithm == "" {
+		mw.SigningAlgorithm = "HS256"
+	}
+	if mw.Key == nil {
+		log.Fatal("Key required")
+	}
+	if mw.Timeout == 0 {
+		mw.Timeout = time.Hour
+	}
+	if mw.Authenticator == nil {
+		log.Fatal("Authenticator is required")
+	}
+	if mw.Authorizator == nil {
+		mw.Authorizator = func(userId string, request *Request) bool {
+			return true
+		}
+	}
+
+	return func(writer ResponseWriter, request *Request) { mw.middlewareImpl(writer, request, handler) }
+}
+
+func (mw *JWTMiddleware) middlewareImpl(writer ResponseWriter, request *Request, handler HandlerFunc) {
+	authHeader := request.Header.Get("Authorization")
+
+	if authHeader == "" {
+		mw.unauthorized(writer)
+		return
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if !(len(parts) == 2 && parts[0] == "Bearer") {
+		mw.unauthorized(writer)
+		return
+	}
+
+	token, err := jwt.Parse(parts[1], func(token *jwt.Token) (interface{}, error) {
+		return mw.Key, nil
+	})
+
+	if err != nil {
+		mw.unauthorized(writer)
+		return
+	}
+
+	id := token.Claims["id"].(string)
+
+	if !mw.Authorizator(id, request) {
+		mw.unauthorized(writer)
+		return
+	}
+
+	request.Env["REMOTE_USER"] = id
+	handler(writer, request)
+}
+
+type login struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// Handler that clients can use to get jwt token
+// Reply will be of the form {"token": "TOKEN"}
+func (mw *JWTMiddleware) LoginHandler(writer ResponseWriter, request *Request) {
+	login_vals := login{}
+	err := request.DecodeJsonPayload(&login_vals)
+
+	if err != nil {
+		mw.unauthorized(writer)
+		return
+	}
+
+	if !mw.Authenticator(login_vals.Username, login_vals.Password) {
+		mw.unauthorized(writer)
+		return
+	}
+
+	token := jwt.New(jwt.GetSigningMethod(mw.SigningAlgorithm))
+	token.Claims["id"] = login_vals.Username
+	token.Claims["exp"] = time.Now().Add(mw.Timeout).Unix()
+	tokenString, err := token.SignedString(mw.Key)
+
+	if err != nil {
+		mw.unauthorized(writer)
+		return
+	}
+
+	writer.WriteJson(&map[string]string{"token": tokenString})
+}
+
+func (mw *JWTMiddleware) unauthorized(writer ResponseWriter) {
+	writer.Header().Set("WWW-Authenticate", "Basic realm="+mw.Realm)
+	Error(writer, "Not Authorized", http.StatusUnauthorized)
+}

--- a/rest/jwt_auth_test.go
+++ b/rest/jwt_auth_test.go
@@ -1,0 +1,145 @@
+package rest
+
+import (
+	"github.com/ant0ine/go-json-rest/rest/test"
+	"github.com/dgrijalva/jwt-go"
+	"testing"
+	"time"
+)
+
+func makeTokenString(username string, key []byte) string {
+	token := jwt.New(jwt.GetSigningMethod("HS256"))
+	token.Claims["id"] = "admin"
+	token.Claims["exp"] = time.Now().Add(time.Hour).Unix()
+	tokenString, _ := token.SignedString(key)
+	return tokenString
+}
+
+func TestAuthJWT(t *testing.T) {
+	key := []byte("secret key")
+
+	// the middleware to test
+	authMiddleware := &JWTMiddleware{
+		Realm:   "test zone",
+		Key:     key,
+		Timeout: time.Hour,
+		Authenticator: func(userId string, password string) bool {
+			if userId == "admin" && password == "admin" {
+				return true
+			}
+			return false
+		},
+		Authorizator: func(userId string, request *Request) bool {
+			if request.Method == "GET" {
+				return true
+			}
+			return false
+		},
+	}
+
+	// api for testing failure
+	apiFailure := NewApi()
+	apiFailure.Use(authMiddleware)
+	apiFailure.SetApp(AppSimple(func(w ResponseWriter, r *Request) {
+		t.Error("Should never be executed")
+	}))
+	handler := apiFailure.MakeHandler()
+
+	// simple request fails
+	recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("GET", "http://localhost/", nil))
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// auth with right cred and wrong method fails
+	rightCredReq := test.MakeSimpleRequest("POST", "http://localhost/", nil)
+	rightCredReq.Header.Set("Authorization", "Bearer "+makeTokenString("admin", key))
+	recorded = test.RunRequest(t, handler, rightCredReq)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// wrong Auth format - bearer lower case
+	wrongAuthFormat := test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	wrongAuthFormat.Header.Set("Authorization", "bearer "+makeTokenString("admin", key))
+	recorded = test.RunRequest(t, handler, wrongAuthFormat)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// wrong Auth format - no space after bearer
+	wrongAuthFormat = test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	wrongAuthFormat.Header.Set("Authorization", "bearer"+makeTokenString("admin", key))
+	recorded = test.RunRequest(t, handler, wrongAuthFormat)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// wrong Auth format - empty auth header
+	wrongAuthFormat = test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	wrongAuthFormat.Header.Set("Authorization", "")
+	recorded = test.RunRequest(t, handler, wrongAuthFormat)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// right credt, right method but wrong priv key
+	wrongPrivKeyReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	wrongPrivKeyReq.Header.Set("Authorization", "Bearer "+makeTokenString("admin", []byte("sekret key")))
+	recorded = test.RunRequest(t, handler, wrongPrivKeyReq)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// right credt, right method, right priv key but timeout
+	token := jwt.New(jwt.GetSigningMethod("HS256"))
+	token.Claims["id"] = "admin"
+	token.Claims["exp"] = 0
+	tokenString, _ := token.SignedString(key)
+
+	expiredTimestampReq := test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	expiredTimestampReq.Header.Set("Authorization", "Bearer "+tokenString)
+	recorded = test.RunRequest(t, handler, expiredTimestampReq)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// api for testing success
+	apiSuccess := NewApi()
+	apiSuccess.Use(authMiddleware)
+	apiSuccess.SetApp(AppSimple(func(w ResponseWriter, r *Request) {
+		if r.Env["REMOTE_USER"] == nil {
+			t.Error("REMOTE_USER is nil")
+		}
+		user := r.Env["REMOTE_USER"].(string)
+		if user != "admin" {
+			t.Error("REMOTE_USER is expected to be 'admin'")
+		}
+		w.WriteJson(map[string]string{"Id": "123"})
+	}))
+
+	// auth with right cred and right method succeeds
+	rightCredReq = test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	rightCredReq.Header.Set("Authorization", "Bearer "+makeTokenString("admin", key))
+	recorded = test.RunRequest(t, apiSuccess.MakeHandler(), rightCredReq)
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+
+	// login tests
+	loginApi := NewApi()
+	loginApi.SetApp(AppSimple(authMiddleware.LoginHandler))
+
+	// wrong login
+	wrongLoginCreds := map[string]string{"username": "admin", "password": "admIn"}
+	wrongLoginReq := test.MakeSimpleRequest("POST", "http://localhost/", wrongLoginCreds)
+	recorded = test.RunRequest(t, loginApi.MakeHandler(), wrongLoginReq)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// empty login
+	emptyLoginCreds := map[string]string{}
+	emptyLoginReq := test.MakeSimpleRequest("POST", "http://localhost/", emptyLoginCreds)
+	recorded = test.RunRequest(t, loginApi.MakeHandler(), emptyLoginReq)
+	recorded.CodeIs(401)
+	recorded.ContentTypeIsJson()
+
+	// correct login
+	loginCreds := map[string]string{"username": "admin", "password": "admin"}
+	rightCredReq = test.MakeSimpleRequest("POST", "http://localhost/", loginCreds)
+	recorded = test.RunRequest(t, loginApi.MakeHandler(), rightCredReq)
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+}


### PR DESCRIPTION
This PR adds a middleware for Json-Web-Token authentication (JWT). I use the [jwt-go](https://github.com/dgrijalva/jwt-go) package for the jwt implementation. I don't know what your stance on third-party packages is as I think this would be the first one. 

I have mirrored the rest to be in line with the basic auth middleware.

If you like this we can expand it by adding more signing algorithms and adding a refresh option. Also, I can add an [example](https://gist.github.com/StephanDollberg/b99dbbf3620b70cc0f0d) to the readme.

Looking forward to hear your feedback!