### PR TITLE
Simplified version of routes api

### DIFF
--- a/rest/delete.go
+++ b/rest/delete.go
@@ -1,0 +1,6 @@
+package rest
+
+type Delete struct {
+	PathExp string
+	Func HandlerFunc
+}

--- a/rest/get.go
+++ b/rest/get.go
@@ -1,0 +1,6 @@
+package rest
+
+type Get struct {
+	PathExp string
+	Func HandlerFunc
+}

--- a/rest/gzip_test.go
+++ b/rest/gzip_test.go
@@ -72,3 +72,29 @@ func TestGzipDisabled(t *testing.T) {
 	recorded.HeaderIs("Content-Encoding", "")
 	recorded.HeaderIs("Vary", "")
 }
+
+func TestGzipDisabledSimply(t *testing.T) {
+
+	api := NewApi()
+
+	// router app with success and error paths
+	router, err := MakeRouterSimply(
+		Get{"/ok",
+			func(w ResponseWriter, r *Request) {
+				w.WriteJson(map[string]string{"Id": "123"})
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	api.SetApp(router)
+	handler := api.MakeHandler()
+
+	recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("GET", "http://localhost/ok", nil))
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+	recorded.HeaderIs("Content-Encoding", "")
+	recorded.HeaderIs("Vary", "")
+}

--- a/rest/jsonp_test.go
+++ b/rest/jsonp_test.go
@@ -44,3 +44,43 @@ func TestJsonpMiddleware(t *testing.T) {
 	recorded.HeaderIs("Content-Type", "text/javascript")
 	recorded.BodyIs("parseResponse({\"Error\":\"jsonp error\"})")
 }
+
+func TestJsonpMiddlewareSimply(t *testing.T) {
+
+	api := NewApi()
+
+	// the middleware to test
+	api.Use(&JsonpMiddleware{})
+
+	// router app with success and error paths
+	router, err := MakeRouterSimply(
+		Get{"/ok",
+			func(w ResponseWriter, r *Request) {
+				w.WriteJson(map[string]string{"Id": "123"})
+			},
+		},
+		Get{"/error",
+			func(w ResponseWriter, r *Request) {
+				Error(w, "jsonp error", 500)
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	api.SetApp(router)
+
+	// wrap all
+	handler := api.MakeHandler()
+
+	recorded := test.RunRequest(t, handler, test.MakeSimpleRequest("GET", "http://localhost/ok?callback=parseResponse", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("Content-Type", "text/javascript")
+	recorded.BodyIs("parseResponse({\"Id\":\"123\"})")
+
+	recorded = test.RunRequest(t, handler, test.MakeSimpleRequest("GET", "http://localhost/error?callback=parseResponse", nil))
+	recorded.CodeIs(500)
+	recorded.HeaderIs("Content-Type", "text/javascript")
+	recorded.BodyIs("parseResponse({\"Error\":\"jsonp error\"})")
+}

--- a/rest/post.go
+++ b/rest/post.go
@@ -1,0 +1,6 @@
+package rest
+
+type Post struct {
+	PathExp string
+	Func HandlerFunc
+}

--- a/rest/put.go
+++ b/rest/put.go
@@ -1,0 +1,6 @@
+package rest
+
+type Put struct {
+	PathExp string
+	Func HandlerFunc
+}

--- a/rest/router.go
+++ b/rest/router.go
@@ -19,6 +19,10 @@ type router struct {
 // MakeRouter returns the router app. Given a set of Routes, it dispatches the request to the
 // HandlerFunc of the first route that matches. The order of the Routes matters.
 func MakeRouter(routes ...*Route) (App, error) {
+	return prepareRoutes(routes)
+}
+
+func prepareRoutes(routes []*Route) (App, error) {
 	r := &router{
 		Routes: routes,
 	}
@@ -28,6 +32,25 @@ func MakeRouter(routes ...*Route) (App, error) {
 	}
 	return r, nil
 }
+
+func MakeRouterSimply(routes ... interface{})(App, error) {
+	result := []*Route{}
+	for _, name := range routes {
+		switch v := name.(type) {
+		case Get:
+			result = append(result, &Route{"GET", v.PathExp, v.Func})
+		case Post:
+			result = append(result, &Route{"POST", v.PathExp, v.Func})
+		case Put:
+			result = append(result, &Route{"PUT", v.PathExp, v.Func})
+		case Delete:
+			result = append(result, &Route{"DELETE", v.PathExp, v.Func})
+		}
+	}
+
+	return prepareRoutes(result)
+}
+
 
 // Handle the REST routing and run the user code.
 func (rt *router) AppFunc() HandlerFunc {

--- a/rest/update.go
+++ b/rest/update.go
@@ -1,0 +1,6 @@
+package rest
+
+type Update struct {
+	PathExp string
+	Func HandlerFunc
+}


### PR DESCRIPTION
Hi!
I've just made simple version of Routes api. In the example with countries it will be looks like:
```go
router, err := rest.MakeRouterSimply(
        rest.Get{"/countries", GetAllCountries},
        rest.Post{"/countries", PostCountry},
        rest.Get{"/countries/:code", GetCountry},
        rest.Delete{"/countries/:code", DeleteCountry},
    )
```
Current version is:
```go
router, err := rest.MakeRouter(
        &rest.Route{"GET", "/countries", GetAllCountries},
        &rest.Route{"POST", "/countries", PostCountry},
        &rest.Route{"GET", "/countries/:code", GetCountry},
        &rest.Route{"DELETE", "/countries/:code", DeleteCountry},
    )
```
In the result, its just a high level version on current api. In my point of view, it looks more pretty, but what do you think about that?