### PR TITLE
Introduce shortcuts to create Routes

### DIFF
--- a/rest/doc.go
+++ b/rest/doc.go
@@ -34,7 +34,7 @@
 //              api := rest.NewApi()
 //              api.Use(rest.DefaultDevStack...)
 //              router, err := rest.MakeRouter(
-//                      rest.Route{"GET", "/users/:id", GetUser},
+//                      rest.Get("/users/:id", GetUser),
 //              )
 //              if err != nil {
 //                      log.Fatal(err)

--- a/rest/gzip_test.go
+++ b/rest/gzip_test.go
@@ -14,16 +14,12 @@ func TestGzipEnabled(t *testing.T) {
 
 	// router app with success and error paths
 	router, err := MakeRouter(
-		&Route{"GET", "/ok",
-			func(w ResponseWriter, r *Request) {
-				w.WriteJson(map[string]string{"Id": "123"})
-			},
-		},
-		&Route{"GET", "/error",
-			func(w ResponseWriter, r *Request) {
-				Error(w, "gzipped error", 500)
-			},
-		},
+		Get("/ok", func(w ResponseWriter, r *Request) {
+			w.WriteJson(map[string]string{"Id": "123"})
+		}),
+		Get("/error", func(w ResponseWriter, r *Request) {
+			Error(w, "gzipped error", 500)
+		}),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -53,11 +49,9 @@ func TestGzipDisabled(t *testing.T) {
 
 	// router app with success and error paths
 	router, err := MakeRouter(
-		&Route{"GET", "/ok",
-			func(w ResponseWriter, r *Request) {
-				w.WriteJson(map[string]string{"Id": "123"})
-			},
-		},
+		Get("/ok", func(w ResponseWriter, r *Request) {
+			w.WriteJson(map[string]string{"Id": "123"})
+		}),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/rest/handler_test.go
+++ b/rest/handler_test.go
@@ -15,39 +15,29 @@ func TestHandler(t *testing.T) {
 		ErrorLogger: log.New(ioutil.Discard, "", 0),
 	}
 	handler.SetRoutes(
-		&Route{"GET", "/r/:id",
-			func(w ResponseWriter, r *Request) {
-				id := r.PathParam("id")
-				w.WriteJson(map[string]string{"Id": id})
-			},
-		},
-		&Route{"POST", "/r/:id",
-			func(w ResponseWriter, r *Request) {
-				// JSON echo
-				data := map[string]string{}
-				err := r.DecodeJsonPayload(&data)
-				if err != nil {
-					t.Fatal(err)
-				}
-				w.WriteJson(data)
-			},
-		},
-		&Route{"GET", "/auto-fails",
-			func(w ResponseWriter, r *Request) {
-				a := []int{}
-				_ = a[0]
-			},
-		},
-		&Route{"GET", "/user-error",
-			func(w ResponseWriter, r *Request) {
-				Error(w, "My error", 500)
-			},
-		},
-		&Route{"GET", "/user-notfound",
-			func(w ResponseWriter, r *Request) {
-				NotFound(w, r)
-			},
-		},
+		Get("/r/:id", func(w ResponseWriter, r *Request) {
+			id := r.PathParam("id")
+			w.WriteJson(map[string]string{"Id": id})
+		}),
+		Post("/r/:id", func(w ResponseWriter, r *Request) {
+			// JSON echo
+			data := map[string]string{}
+			err := r.DecodeJsonPayload(&data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			w.WriteJson(data)
+		}),
+		Get("/auto-fails", func(w ResponseWriter, r *Request) {
+			a := []int{}
+			_ = a[0]
+		}),
+		Get("/user-error", func(w ResponseWriter, r *Request) {
+			Error(w, "My error", 500)
+		}),
+		Get("/user-notfound", func(w ResponseWriter, r *Request) {
+			NotFound(w, r)
+		}),
 	)
 
 	// valid get resource

--- a/rest/jsonp_test.go
+++ b/rest/jsonp_test.go
@@ -14,16 +14,12 @@ func TestJsonpMiddleware(t *testing.T) {
 
 	// router app with success and error paths
 	router, err := MakeRouter(
-		&Route{"GET", "/ok",
-			func(w ResponseWriter, r *Request) {
-				w.WriteJson(map[string]string{"Id": "123"})
-			},
-		},
-		&Route{"GET", "/error",
-			func(w ResponseWriter, r *Request) {
-				Error(w, "jsonp error", 500)
-			},
-		},
+		Get("/ok", func(w ResponseWriter, r *Request) {
+			w.WriteJson(map[string]string{"Id": "123"})
+		}),
+		Get("/error", func(w ResponseWriter, r *Request) {
+			Error(w, "jsonp error", 500)
+		}),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/rest/route.go
+++ b/rest/route.go
@@ -4,7 +4,8 @@ import (
 	"strings"
 )
 
-// Route defines a route. It's used with SetRoutes.
+// Route defines a route as consumed by the router. It can be instantiated directly, or using one
+// of the shortcut methods: rest.Get, rest.Post, rest.Put, and rest.Delete.
 type Route struct {
 
 	// Any HTTP method. It will be used as uppercase to avoid common mistakes.
@@ -36,7 +37,8 @@ func (route *Route) MakePath(pathParams map[string]string) string {
 	return path
 }
 
-// Get is a shortcut method that instantiates a GET route. Equivalent to &Route{"GET", pathExp, handlerFunc}
+// Get is a shortcut method that instantiates a GET route. See the Route object the parameters definitions.
+// Equivalent to &Route{"GET", pathExp, handlerFunc}
 func Get(pathExp string, handlerFunc HandlerFunc) *Route {
 	return &Route{
 		HttpMethod: "GET",
@@ -45,7 +47,8 @@ func Get(pathExp string, handlerFunc HandlerFunc) *Route {
 	}
 }
 
-// Post is a shortcut method that instantiates a POST route. Equivalent to &Route{"POST", pathExp, handlerFunc}
+// Post is a shortcut method that instantiates a POST route. See the Route object the parameters definitions.
+// Equivalent to &Route{"POST", pathExp, handlerFunc}
 func Post(pathExp string, handlerFunc HandlerFunc) *Route {
 	return &Route{
 		HttpMethod: "POST",
@@ -54,7 +57,8 @@ func Post(pathExp string, handlerFunc HandlerFunc) *Route {
 	}
 }
 
-// Put is a shortcut method that instantiates a PUT route. Equivalent to &Route{"PUT", pathExp, handlerFunc}
+// Put is a shortcut method that instantiates a PUT route.  See the Route object the parameters definitions.
+// Equivalent to &Route{"PUT", pathExp, handlerFunc}
 func Put(pathExp string, handlerFunc HandlerFunc) *Route {
 	return &Route{
 		HttpMethod: "PUT",

--- a/rest/route.go
+++ b/rest/route.go
@@ -35,3 +35,39 @@ func (route *Route) MakePath(pathParams map[string]string) string {
 	}
 	return path
 }
+
+// Get is a shortcut method that instantiates a GET route. Equivalent to &Route{"GET", pathExp, handlerFunc}
+func Get(pathExp string, handlerFunc HandlerFunc) *Route {
+	return &Route{
+		HttpMethod: "GET",
+		PathExp:    pathExp,
+		Func:       handlerFunc,
+	}
+}
+
+// Post is a shortcut method that instantiates a POST route. Equivalent to &Route{"POST", pathExp, handlerFunc}
+func Post(pathExp string, handlerFunc HandlerFunc) *Route {
+	return &Route{
+		HttpMethod: "POST",
+		PathExp:    pathExp,
+		Func:       handlerFunc,
+	}
+}
+
+// Put is a shortcut method that instantiates a PUT route. Equivalent to &Route{"PUT", pathExp, handlerFunc}
+func Put(pathExp string, handlerFunc HandlerFunc) *Route {
+	return &Route{
+		HttpMethod: "PUT",
+		PathExp:    pathExp,
+		Func:       handlerFunc,
+	}
+}
+
+// Delete is a shortcut method that instantiates a DELETE route. Equivalent to &Route{"DELETE", pathExp, handlerFunc}
+func Delete(pathExp string, handlerFunc HandlerFunc) *Route {
+	return &Route{
+		HttpMethod: "DELETE",
+		PathExp:    pathExp,
+		Func:       handlerFunc,
+	}
+}

--- a/rest/route_test.go
+++ b/rest/route_test.go
@@ -48,3 +48,26 @@ func TestReverseRouteResolution(t *testing.T) {
 		t.Errorf("expected %s, got %s", expected, got)
 	}
 }
+
+func TestShortcutMethods(t *testing.T) {
+
+	r := Get("/", nil)
+	if r.HttpMethod != "GET" {
+		t.Errorf("expected GET, got %s", r.HttpMethod)
+	}
+
+	r = Post("/", nil)
+	if r.HttpMethod != "POST" {
+		t.Errorf("expected POST, got %s", r.HttpMethod)
+	}
+
+	r = Put("/", nil)
+	if r.HttpMethod != "PUT" {
+		t.Errorf("expected PUT, got %s", r.HttpMethod)
+	}
+
+	r = Delete("/", nil)
+	if r.HttpMethod != "DELETE" {
+		t.Errorf("expected DELETE, got %s", r.HttpMethod)
+	}
+}

--- a/rest/test/doc.go
+++ b/rest/test/doc.go
@@ -15,11 +15,9 @@
 //	func TestSimpleRequest(t *testing.T) {
 //		handler := ResourceHandler{}
 //		handler.SetRoutes(
-//			&Route{"GET", "/r",
-//				func(w ResponseWriter, r *Request) {
-//					w.WriteJson(map[string]string{"Id": "123"})
-//				},
-//			},
+//			Get("/r", func(w ResponseWriter, r *Request) {
+//				w.WriteJson(map[string]string{"Id": "123"})
+//			}),
 //		)
 //		recorded := test.RunRequest(t, &handler,
 //			test.MakeSimpleRequest("GET", "http://1.2.3.4/r", nil))


### PR DESCRIPTION
The four new methods Get, Post, Put and Delete are simple constructors
for the Route objects.

Intantiating the Route object directly is still supported, and allows
the framework to handle any HTTP method.

These shortcuts are there to save keystrokes, improve readability and
to play nicely with golint. (which likes to have key typed in the literals)