### PR TITLE
Load all static assets over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>Go-json-rest by ant0ine</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
   </head>
@@ -24,7 +24,7 @@
 
 <p><em>A quick and easy way to setup a RESTful JSON API</em></p>
 
-<p><a href="https://godoc.org/github.com/ant0ine/go-json-rest/rest"><img src="http://img.shields.io/badge/godoc-reference-blue.svg?style=flat" alt="godoc"></a> <a href="https://raw.githubusercontent.com/ant0ine/go-json-rest/master/LICENSE"><img src="http://img.shields.io/badge/license-MIT-red.svg?style=flat" alt="license"></a> <a href="https://travis-ci.org/ant0ine/go-json-rest"><img src="https://img.shields.io/travis/ant0ine/go-json-rest.svg?style=flat" alt="build"></a></p>
+<p><a href="https://godoc.org/github.com/ant0ine/go-json-rest/rest"><img src="https://img.shields.io/badge/godoc-reference-blue.svg?style=flat" alt="godoc"></a> <a href="https://raw.githubusercontent.com/ant0ine/go-json-rest/master/LICENSE"><img src="https://img.shields.io/badge/license-MIT-red.svg?style=flat" alt="license"></a> <a href="https://travis-ci.org/ant0ine/go-json-rest"><img src="https://img.shields.io/travis/ant0ine/go-json-rest.svg?style=flat" alt="build"></a></p>
 
 <p><strong>Go-Json-Rest</strong> is a thin layer on top of <code>net/http</code> that helps building RESTful JSON APIs easily. It provides fast and scalable request routing using a Trie based implementation, helpers to deal with JSON requests and responses, and middlewares for functionalities like CORS, Auth, Gzip, Status ...</p>
 


### PR DESCRIPTION
When visiting the [documentation](https://ant0ine.github.io/go-json-rest/) over https Chrome displays a warning that some assets on the page were loaded over http.

This PR attempts to fix this.