### PR TITLE
Gzip content when content length equal or greater than minimum length

### DIFF
--- a/rest/gzip_test.go
+++ b/rest/gzip_test.go
@@ -1,8 +1,15 @@
 package rest
 
 import (
-	"github.com/ant0ine/go-json-rest/rest/test"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/ant0ine/go-json-rest/rest/test"
 )
 
 func TestGzipEnabled(t *testing.T) {
@@ -65,4 +72,54 @@ func TestGzipDisabled(t *testing.T) {
 	recorded.ContentTypeIsJson()
 	recorded.HeaderIs("Content-Encoding", "")
 	recorded.HeaderIs("Vary", "")
+}
+
+func TestGzipMinLength(t *testing.T) {
+	api := NewApi()
+
+	// the middleware to test
+	api.Use(&GzipMiddleware{
+		MinLength: 1024,
+	})
+
+	router, _ := MakeRouter(
+		Post("/gzip", func(w ResponseWriter, r *Request) {
+			defer r.Body.Close()
+			io.Copy(w.(http.ResponseWriter), r.Body)
+		}),
+	)
+
+	api.SetApp(router)
+	ts := httptest.NewServer(api.MakeHandler())
+	defer ts.Close()
+
+	c := &http.Client{}
+
+	// test payload content length over min length
+	payload := map[string]string{
+		"data": strings.Repeat("A", 1024),
+	}
+
+	req := test.MakeSimpleRequest("POST", ts.URL+"/gzip", payload)
+	resp, _ := c.Do(req)
+
+	length, _ := strconv.Atoi(resp.Header.Get("Content-Length"))
+	if length >= 1024 {
+		t.Error("Expect 'Content-Length' should less than 1024 but got", length)
+	}
+
+	// test payload content length less than min length
+	payload = map[string]string{
+		"data": strings.Repeat("A", 1),
+	}
+	b, _ := json.Marshal(payload)
+	contentLength := len(b)
+
+	req = test.MakeSimpleRequest("POST", ts.URL+"/gzip", payload)
+	resp, _ = c.Do(req)
+
+	length, _ = strconv.Atoi(resp.Header.Get("Content-Length"))
+	if length != contentLength {
+		t.Errorf("Expect 'Content-Length' should equal %d but got %d", contentLength, length)
+	}
 }


### PR DESCRIPTION
Hi @ant0ine 

From #99, I modify `GzipMiddleware` to check length from `Content-Length` header before compress content for prevented to compress small size content.

Thank
Thanabodee