### PR TITLE
add a middleware to redirect http to https

### DIFF
--- a/rest/redirect.go
+++ b/rest/redirect.go
@@ -1,0 +1,22 @@
+package rest
+
+import (
+	"net/http"
+	"strings"
+)
+
+// SecureRedirectMiddleware redirects the client to the identical URL served via HTTPS
+type SecureRedirectMiddleware struct{}
+
+func (SecureRedirectMiddleware) MiddlewareFunc(h HandlerFunc) HandlerFunc {
+	return func(w ResponseWriter, r *Request) {
+		if strings.ToLower(r.Header.Get("X-Forwarded-Proto")) == "http" {
+			redirectURL := r.URL
+			redirectURL.Host = r.Host
+			redirectURL.Scheme = "https"
+			http.Redirect(w.(http.ResponseWriter), r.Request, redirectURL.String(), http.StatusMovedPermanently)
+			return
+		}
+		h(w, r)
+	}
+}

--- a/rest/redirect_test.go
+++ b/rest/redirect_test.go
@@ -1,0 +1,28 @@
+package rest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ant0ine/go-json-rest/rest/test"
+)
+
+func TestSecureRedirectMiddleware(t *testing.T) {
+	api := NewApi()
+	api.Use(&SecureRedirectMiddleware{})
+	api.SetApp(AppSimple(func(w ResponseWriter, r *Request) {
+		w.WriteJson(map[string]string{"Id": "123"})
+	}))
+	handler := api.MakeHandler()
+
+	req := test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	req.Header.Set("X-Forwarded-Proto", "HtTp")
+	recorded := test.RunRequest(t, handler, req)
+	recorded.CodeIs(http.StatusMovedPermanently)
+	recorded.HeaderIs("Location", "https://localhost/")
+
+	req = test.MakeSimpleRequest("GET", "http://localhost/", nil)
+	recorded = test.RunRequest(t, handler, req)
+	recorded.CodeIs(http.StatusOK)
+	recorded.BodyIs(`{"Id":"123"}`)
+}


### PR DESCRIPTION
This is useful behind cloud-based load balancers (like AWS ELBs) to
force clients to use SSL.