### PR TITLE
minor fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,9 +931,9 @@ Demonstrates how to use the [Json Web Token Auth Middleware](https://github.com/
 
 curl demo:
 ``` sh
-curl -d '{"username": "admin", "password": "admin"}' -H "Content-Type:application/json" http://localhost:8080/api/login
-curl -H "Authorization:Bearer TOKEN_RETURNED_FROM_ABOVE" http://localhost:8080/api/auth_test
-curl -H "Authorization:Bearer TOKEN_RETURNED_FROM_ABOVE" http://localhost:8080/api/refresh_token
+curl -d '{"username": "admin", "password": "admin"}' -H "Content-Type:application/json" http://localhost:8080/login
+curl -H "Authorization:Bearer TOKEN_RETURNED_FROM_ABOVE" http://localhost:8080/auth_test
+curl -H "Authorization:Bearer TOKEN_RETURNED_FROM_ABOVE" http://localhost:8080/refresh_token
 ```
 
 code:


### PR DESCRIPTION
There was a small mistake in JWT section - http://localhost:8080/api/auth_test used in curl call instead of http://localhost:8080/auth_test 