### PR TITLE
rest/test: ContentTypeIsJson change assertion from match exactly to match prefix

### DIFF
--- a/rest/test/util.go
+++ b/rest/test/util.go
@@ -45,7 +45,7 @@ func CodeIs(t *testing.T, r *httptest.ResponseRecorder, expectedCode int) {
 // HeaderIs tests the first value for the given headerKey
 func HeaderIs(t *testing.T, r *httptest.ResponseRecorder, headerKey, expectedValue string) {
 	value := r.HeaderMap.Get(headerKey)
-	if value != expectedValue {
+	if !strings.HasPrefix(value, expectedValue) {
 		t.Errorf(
 			"%s: %s expected, got: %s",
 			headerKey,


### PR DESCRIPTION
Currently, ContentTypeIsJson match `application/json` exactly. When set content type to `application/json; charset=utf-8`, it will fail. This pr change from `!=` to `strings.HasPrefix` to match content type that begin with `application/json` and ignore charset.

This pr related to #160 