### PR TITLE
ResponseWriter adds a new function `ErrorCustom` to produces a custom error response. 

### DIFF
--- a/rest/response.go
+++ b/rest/response.go
@@ -45,6 +45,16 @@ func Error(w ResponseWriter, error string, code int) {
 	}
 }
 
+// ErrorCustom produces a custom error response in JSON with the custom structure,
+// e.g. '{"Code": "1001", "Error":"My error message"}'
+func ErrorCustom(w ResponseWriter, error interface{}, code int) {
+	w.WriteHeader(code)
+	err := w.WriteJson(error)
+	if err != nil {
+		panic(err)
+	}
+}
+
 // NotFound produces a 404 response with the following JSON, '{"Error":"Resource not found"}'
 // The standard plain text net/http NotFound helper can still be called like this:
 // http.NotFound(w, r.Request)


### PR DESCRIPTION
Our RESTful apis usually have custom error code when the request failed. But the custom err code is not equal to http status code which specified in RFC document. If we use custom status code instead of regular http status code , some iOS networking framework e.g. AFNetworking do not supported it, so we need a new function rest.ErrorCustom like this:
````
func ErrorCustom(w ResponseWriter, error interface{}, httpStatusCode int) 
````