### PR TITLE
Add shortcut support for TRACE route

### DIFF
--- a/rest/route.go
+++ b/rest/route.go
@@ -96,6 +96,15 @@ func Delete(pathExp string, handlerFunc HandlerFunc) *Route {
 	}
 }
 
+// Trace is a shortcut method that instantiates a TRACE route. Equivalent to &Route{"TRACE", pathExp, handlerFunc}
+func Trace(pathExp string, handlerFunc HandlerFunc) *Route {
+	return &Route{
+		HttpMethod: "TRACE",
+		PathExp:    pathExp,
+		Func:       handlerFunc,
+	}
+}
+
 // Options is a shortcut method that instantiates an OPTIONS route.  See the Route object the parameters definitions.
 // Equivalent to &Route{"OPTIONS", pathExp, handlerFunc}
 func Options(pathExp string, handlerFunc HandlerFunc) *Route {


### PR DESCRIPTION
Added the ability to create HTTP TRACE routes using the shortcut methods.

```go
package main

import (
    "github.com/ant0ine/go-json-rest/rest"
    "log"
    "net/http"
)

func main() {
    api := rest.NewApi()
    router, err := rest.MakeRouter(
        rest.Trace("/", func(w rest.ResponseWriter, req *rest.Request) {
            w.WriteJson("Trace method called")
        }),
    )
    if err != nil {
        log.Fatal(err)
    }
    api.SetApp(router)
    log.Fatal(http.ListenAndServe(":8080", api.MakeHandler()))
}
```