### PR TITLE
Add support for customisation of error response payload

### DIFF
--- a/rest/response.go
+++ b/rest/response.go
@@ -34,14 +34,26 @@ type ResponseWriter interface {
 // eg: rest.ErrorFieldName = "errorMessage"
 var ErrorFieldName = "Error"
 
+// Private customErrorHandler used for defining custom error response payloads.
+type customErrorHandler func(ResponseWriter, int)
+
+// ErrorHandler allows to customize the error response payload entirely.
+// It default to nil, resulting in the default error respone payload to be displayed.
+// eg: rest.ErrorHandler = func (w api.ResponseWriter, code int) { w.WriteJson(code) }
+var ErrorHandler customErrorHandler
+
 // Error produces an error response in JSON with the following structure, '{"Error":"My error message"}'
 // The standard plain text net/http Error helper can still be called like this:
 // http.Error(w, "error message", code)
 func Error(w ResponseWriter, error string, code int) {
-	w.WriteHeader(code)
-	err := w.WriteJson(map[string]string{ErrorFieldName: error})
-	if err != nil {
-		panic(err)
+	if ErrorHandler != nil {
+		ErrorHandler(w, code)
+	} else {
+		w.WriteHeader(code)
+		err := w.WriteJson(map[string]string{ErrorFieldName: error})
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
Added support for customisation of error responses using a custom error handler function. This allows to customise the format and structure of all error messages generated by go-json-rest, if needed.

This should be more versatile than the pull request suggested in #174, and does not add another method which would probably go unused in most implementations.

### Example 1 (inline method)

```go
package main

import (
    "github.com/ant0ine/go-json-rest/rest"
    "log"
    "net/http"
)

func main() {
    api := rest.NewApi()
    rest.ErrorHandler = func(w rest.ResponseWriter, code int) {
        w.WriteHeader(code)
        w.WriteJson(code)
    }
    router, err := rest.MakeRouter(
        rest.Trace("/", func(w rest.ResponseWriter, req *rest.Request) {
            w.WriteJson("Trace method called")
        }),
    )
    if err != nil {
        log.Fatal(err)
    }
    api.SetApp(router)
    log.Fatal(http.ListenAndServe(":8080", api.MakeHandler()))
}

func errors(w api.ResponseWriter, code int) {
	w.WriteHeader(code)
	w.WriteJson(code)
}
```

### Example 2 (extensive configuration)

```go
package main

import (
    "github.com/ant0ine/go-json-rest/rest"
    "log"
    "net/http"
)

func main() {
    api := rest.NewApi()
    rest.ErrorHandler = errors
    router, err := rest.MakeRouter(
        rest.Trace("/", func(w rest.ResponseWriter, req *rest.Request) {
            w.WriteJson("Trace method called")
        }),
    )
    if err != nil {
        log.Fatal(err)
    }
    api.SetApp(router)
    log.Fatal(http.ListenAndServe(":8080", api.MakeHandler()))
}
```

```go
package main

import (
    "github.com/ant0ine/go-json-rest/rest"
)

func errors(w rest.ResponseWriter, code int) {
	w.WriteHeader(code)
	w.WriteJson(errs[code])
}

var errs = map[int]interface{}{

	404: map[string]interface{}{
		"code":          404,
		"details":       "Request resource not found",
		"information":   "The requested resource does not exist. Check that you have entered the url correctly.",
	},

	405: map[string]interface{}{
		"code":          405,
		"details":       "This method is not allowed",
		"information":   "The requested http method is not allowed for this resource. Refer to the documentation for allowed methods.",
	},

	415: map[string]interface{}{
		"code":          415,
		"details":       "Unsupported content type requested",
		"information":   "Requests to the api must use the 'Content-Type: application/json' header. Check your request settings and try again.",
	},

	500: map[string]interface{}{
		"code":          500,
		"details":       "There was a problem with our servers, and we have been notified",
	},

}

```