### PR TITLE
Use net.SplitHostPort so ipv6 addresses get parsed properly

### DIFF
--- a/rest/access_log_apache.go
+++ b/rest/access_log_apache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"strings"
 	"text/template"
@@ -195,8 +196,9 @@ func (u *accessLogUtil) StartTime() *time.Time {
 func (u *accessLogUtil) ApacheRemoteAddr() string {
 	remoteAddr := u.R.RemoteAddr
 	if remoteAddr != "" {
-		parts := strings.SplitN(remoteAddr, ":", 2)
-		return parts[0]
+		if ip, _, err := net.SplitHostPort(remoteAddr); err == nil {
+			return ip
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
Splitting on ':' doesn't exactly work for ipv6, just end up with the left bracket and possibly the first quartet.