### PR TITLE
rest.ResponseWriter: add Write() function to conform to io.Writer interface

### DIFF
--- a/rest/response.go
+++ b/rest/response.go
@@ -15,6 +15,9 @@ type ResponseWriter interface {
 	// Identical to the http.ResponseWriter interface
 	Header() http.Header
 
+	// Provided in order to implement the http.ResponseWriter interface.
+	Write(b []byte) (int, error)
+
 	// Use EncodeJson to generate the payload, write the headers with http.StatusOK if
 	// they are not already written, then write the payload.
 	// The Content-Type header is set to "application/json", unless already specified.


### PR DESCRIPTION
Hi,

In my project, I would like to pass an instance of `rest.ResponseWriter` to another function that expects to consume an `io.Writer`. roughly like so:

```
  86         rest.Get("/debug/metrics", func(w rest.ResponseWriter, r *rest.Request) {
  87             metrics.WriteJSONOnce(metrics.DefaultRegistry, w)
  88         }),
```

However, the following compilation error results on `go version go1.6.2 linux/amd64`:

```
worker/worker.go:87: cannot use w (type rest.ResponseWriter) as type io.Writer in argument to metrics.WriteJSONOnce:
        rest.ResponseWriter does not implement io.Writer (missing Write method)
```

This occurs because while a `func Write(b []byte) (int, error)` method exists, it is not explicitly listed in the type declaration.

This is a simple patch that adds the method signature to the `rest.ResponseWriter` type declaration.  With this, the application code on my end typechecks and a ResponseWriter is able to successfully be used by a function expecting an `io.Writer` type.

Thank you for writing a very useful project!

Nathan
