### PR TITLE
Added Write method to rest ResponseWriter interface.

### DIFF
--- a/rest/response.go
+++ b/rest/response.go
@@ -27,6 +27,9 @@ type ResponseWriter interface {
 	// Similar to the http.ResponseWriter interface, with additional JSON related
 	// headers set.
 	WriteHeader(int)
+
+	// Identical to http.ResponseWritter
+	Write([]byte) (int, error)
 }
 
 // This allows to customize the field name used in the error response payload.


### PR DESCRIPTION
Resolves #192 
I've added this function to satisfy the interface of http.ResponseWriter,
allowing rest.ResponseWriter to be used interchangably with
http.ResponseWriter.
