### PR TITLE
Empty Access-Control-Request-Headers in CORS preflight triggers 403 Forbidden

### DIFF
--- a/rest/cors_test.go
+++ b/rest/cors_test.go
@@ -1,0 +1,43 @@
+package rest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ant0ine/go-json-rest/rest/test"
+)
+
+func TestCorsMiddlewareEmptyAccessControlRequestHeaders(t *testing.T) {
+	api := NewApi()
+
+	// the middleware to test
+	api.Use(&CorsMiddleware{
+		OriginValidator: func(_ string, _ *Request) bool {
+			return true
+		},
+		AllowedMethods: []string{
+			"GET",
+			"POST",
+			"PUT",
+		},
+		AllowedHeaders: []string{
+			"Origin",
+			"Referer",
+		},
+	})
+
+	// wrap all
+	handler := api.MakeHandler()
+
+	req, _ := http.NewRequest("OPTIONS", "http://localhost", nil)
+	req.Header.Set("Origin", "http://another.host")
+	req.Header.Set("Access-Control-Request-Method", "PUT")
+	req.Header.Set("Access-Control-Request-Headers", "")
+
+	recorded := test.RunRequest(t, handler, req)
+	t.Logf("recorded: %+v\n", recorded.Recorder)
+	recorded.CodeIs(200)
+	recorded.HeaderIs("Access-Control-Allow-Methods", "GET,POST,PUT")
+	recorded.HeaderIs("Access-Control-Allow-Headers", "Origin,Referer")
+	recorded.HeaderIs("Access-Control-Allow-Origin", "http://another.host")
+}

--- a/rest/request.go
+++ b/rest/request.go
@@ -120,6 +120,9 @@ func (r *Request) GetCorsInfo() *CorsInfo {
 	reqHeaders := []string{}
 	rawReqHeaders := r.Header[http.CanonicalHeaderKey("Access-Control-Request-Headers")]
 	for _, rawReqHeader := range rawReqHeaders {
+		if len(rawReqHeader) == 0 {
+			continue
+		}
 		// net/http does not handle comma delimited headers for us
 		for _, reqHeader := range strings.Split(rawReqHeader, ",") {
 			reqHeaders = append(reqHeaders, http.CanonicalHeaderKey(strings.TrimSpace(reqHeader)))


### PR DESCRIPTION
See #196 

```
commit ffc80ad01c12cd49434f60d1e94bcea5b040d5e5
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Wed Nov 30 12:28:09 2016 +0100

    rest/cors_test: tests for empty Access-Control-Request-Headers in preflight requests
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

commit 9ec7f2b210af61f2323ccb6528f861fc363f7713
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Wed Nov 30 12:21:47 2016 +0100

    rest/request: skip empty strings in values of Access-Control-Request-Headers
    
    WebKit browsers may send a preflight CORS request setting
    Access-Control-Request-Headers to an empty value, what is in turn interpreted as
    an empty string on Golang's http server side. An example scenario that triggers
    this behavior in Chrome is doing a xhr POST request and setting progress
    callback. Request headers reported by browser's developer tools are then the
    following:
    
    :authority:docker.mender.io:8080
    :method:OPTIONS
    :path:/api/integrations/0.1/deployments/images
    :scheme:https
    accept:*/*
    accept-encoding:gzip, deflate, sdch, br
    accept-language:en-US,en;q=0.8,pl;q=0.6
    access-control-request-headers:      <--- empty value here
    access-control-request-method:POST
    dnt:1
    origin:http://localhost:9999
    referer:http://localhost:9999/test.html
    user-agent:Mozilla/5.0 (X11; Linux x86_64) ...
    
    It is unclear whether in such case, the client wants to send no headers in the
    actual request or just a bug in client's code.
    
    Since the original request is cured and repacked into CorsInfo it makes sense to
    skip Access-Control-Request-Headers values that are empty.
```
