### PR TITLE
Fix HTTPS Scheme when using HTTP2

### DIFF
--- a/rest/request.go
+++ b/rest/request.go
@@ -55,9 +55,9 @@ func (r *Request) BaseUrl() *url.URL {
 		scheme = "http"
 	}
 
-	// HTTP/2.0 gives the default scheme as HTTP even when used with TLS
-	// Check if version 2.0 and TLS is not nil and given back https scheme
-	if scheme == "http" && r.ProtoMajor >= 2 && r.TLS != nil {
+	// HTTP sometimes gives the default scheme as HTTP even when used with TLS
+	// Check if TLS is not nil and given back https scheme
+	if scheme == "http" && r.TLS != nil {
 		scheme = "https"
 	}
 

--- a/rest/request.go
+++ b/rest/request.go
@@ -55,6 +55,12 @@ func (r *Request) BaseUrl() *url.URL {
 		scheme = "http"
 	}
 
+	// HTTP/2.0 gives the default scheme as HTTP even when used with TLS
+	// Check if version 2.0 and TLS is not nil and given back https scheme
+	if scheme == "http" && r.ProtoMajor >= 2 && r.TLS != nil {
+		scheme = "https"
+	}
+
 	host := r.Host
 	if len(host) > 0 && host[len(host)-1] == '/' {
 		host = host[:len(host)-1]

--- a/rest/request_test.go
+++ b/rest/request_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"crypto/tls"
 )
 
 func defaultRequest(method string, urlStr string, body io.Reader, t *testing.T) *Request {
@@ -40,6 +41,30 @@ func TestRequestBaseUrl(t *testing.T) {
 
 func TestRequestUrlScheme(t *testing.T) {
 	req := defaultRequest("GET", "https://localhost", nil, t)
+	urlBase := req.BaseUrl()
+
+	expected := "https"
+	if urlBase.Scheme != expected {
+		t.Error(expected + " was the expected scheme, but instead got " + urlBase.Scheme)
+	}
+}
+
+func TestRequestUrlSchemeHTTP(t *testing.T) {
+	req := defaultRequest("GET", "http://localhost", nil, t)
+	urlBase := req.BaseUrl()
+
+	expected := "http"
+	if urlBase.Scheme != expected {
+		t.Error(expected + " was the expected scheme, but instead got " + urlBase.Scheme)
+	}
+}
+
+func TestRequestUrlSchemeHTTP2TLS(t *testing.T) {
+	req := defaultRequest("GET", "http://localhost", nil, t)
+	req.Proto = "HTTP"
+	req.ProtoMajor = 2
+	req.ProtoMinor = 0
+	req.TLS = &tls.ConnectionState{}
 	urlBase := req.BaseUrl()
 
 	expected := "https"


### PR DESCRIPTION
When using HTTP/2.0 the default scheme given is http. Check if the server is running HTTP/2.0 and if TLS is being used.

Resolves issue https://github.com/ant0ine/go-json-rest/issues/202