### PR TITLE
add another curl request for comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ Demonstrate how to setup CorsMiddleware around all the API endpoints.
 curl demo:
 ```
 curl -i http://127.0.0.1:8080/countries
+curl -H "Origin: http://my.other.host" -i http://127.0.0.1:8080/countries
 ```
 
 code:


### PR DESCRIPTION
The current CORS curl demo will not return a response containing CORS headers.
I think it would be better to add a curl demo that returns a response containing that.

```
$ curl -i http://127.0.0.1:8080/countries
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
X-Powered-By: go-json-rest
Date: Mon, 04 Dec 2017 18:18:01 GMT
Content-Length: 105

[
  {
    "Code": "FR",
    "Name": "France"
  },
  {
    "Code": "US",
    "Name": "United States"
  }
]
```

```
$ curl -H "Origin: http://my.other.host" -i http://127.0.0.1:8080/countries
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://my.other.host
Content-Type: application/json; charset=utf-8
X-Powered-By: go-json-rest
Date: Mon, 04 Dec 2017 18:18:21 GMT
Content-Length: 105

[
  {
    "Code": "FR",
    "Name": "France"
  },
  {
    "Code": "US",
    "Name": "United States"
  }
]
```