### PR TITLE
Adds PathExp to Requests

### DIFF
--- a/rest/middleware.go
+++ b/rest/middleware.go
@@ -58,6 +58,7 @@ func adapterFunc(handler HandlerFunc) http.HandlerFunc {
 		request := &Request{
 			origRequest,
 			nil,
+			"",
 			map[string]interface{}{},
 		}
 

--- a/rest/middleware_test.go
+++ b/rest/middleware_test.go
@@ -40,6 +40,7 @@ func TestWrapMiddlewares(t *testing.T) {
 	r := &Request{
 		nil,
 		nil,
+		"",
 		map[string]interface{}{},
 	}
 

--- a/rest/request.go
+++ b/rest/request.go
@@ -21,6 +21,9 @@ type Request struct {
 	// Map of parameters that have been matched in the URL Path.
 	PathParams map[string]string
 
+	// The PathExp of the route that is safisfying this request
+	PathExp string
+
 	// Environment used by middlewares to communicate.
 	Env map[string]interface{}
 }

--- a/rest/request_test.go
+++ b/rest/request_test.go
@@ -16,6 +16,7 @@ func defaultRequest(method string, urlStr string, body io.Reader, t *testing.T) 
 	return &Request{
 		origReq,
 		nil,
+		"",
 		map[string]interface{}{},
 	}
 }

--- a/rest/router.go
+++ b/rest/router.go
@@ -48,8 +48,9 @@ func (rt *router) AppFunc() HandlerFunc {
 			return
 		}
 
-		// a route was found, set the PathParams
+		// a route was found, set the PathParams and PathExp
 		request.PathParams = params
+		request.PathExp = route.PathExp
 
 		// run the user code
 		handler := route.Func


### PR DESCRIPTION
This adds the PathExp to the Request object so that code downstream of the router is aware which route is  satisfying the current request. Primary motivation for this is to give middlewares some additional information.