### PR TITLE
fix: change &start and &end to "start" and "end"

### DIFF
--- a/rest/timer.go
+++ b/rest/timer.go
@@ -14,13 +14,13 @@ func (mw *TimerMiddleware) MiddlewareFunc(h HandlerFunc) HandlerFunc {
 	return func(w ResponseWriter, r *Request) {
 
 		start := time.Now()
-		r.Env["START_TIME"] = &start
+		r.Env["START_TIME"] = start
 
 		// call the handler
 		h(w, r)
 
 		end := time.Now()
 		elapsed := end.Sub(start)
-		r.Env["ELAPSED_TIME"] = &elapsed
+		r.Env["ELAPSED_TIME"] = elapsed
 	}
 }

--- a/rest/timer_test.go
+++ b/rest/timer_test.go
@@ -19,7 +19,7 @@ func TestTimerMiddleware(t *testing.T) {
 			if r.Env["ELAPSED_TIME"] == nil {
 				t.Error("ELAPSED_TIME is nil")
 			}
-			elapsedTime := r.Env["ELAPSED_TIME"].(*time.Duration)
+			elapsedTime := r.Env["ELAPSED_TIME"].(time.Duration)
 			if elapsedTime.Nanoseconds() <= 0 {
 				t.Errorf(
 					"ELAPSED_TIME is expected to be at least 1 nanosecond %d",
@@ -30,7 +30,7 @@ func TestTimerMiddleware(t *testing.T) {
 			if r.Env["START_TIME"] == nil {
 				t.Error("START_TIME is nil")
 			}
-			start := r.Env["START_TIME"].(*time.Time)
+			start := r.Env["START_TIME"].(time.Time)
 			if start.After(time.Now()) {
 				t.Errorf(
 					"START_TIME is expected to be in the past %s",


### PR DESCRIPTION
I also created a PR because a memory leak occurred in the project I'm using.
Please review.

close #230 